### PR TITLE
FIX HeaderField error expects two constructor args

### DIFF
--- a/src/extensions/PiwikSiteConfigExtension.php
+++ b/src/extensions/PiwikSiteConfigExtension.php
@@ -27,7 +27,7 @@ class PiwikSiteConfigExtension extends DataExtension
 
     public function updateCMSFields(FieldList $fields)
     {
-        $fields->addFieldToTab('Root.Piwik', HeaderField::create('Piwik'));
+        $fields->addFieldToTab('Root.Piwik', HeaderField::create('Piwik', 'Piwik'));
 
         $siteIDField = NumericField::create('PiwikSiteID', _t('Netwerkstatt\\Piwik\\Extensions\\PiwikSiteConfigExtension.db_PiwikSiteID', 'PIWIK Site ID'))
             ->setDescription(_t('Netwerkstatt\\Piwik\\Extensions\\PiwikSiteConfigExtension.SiteIDDescription', 'The ID of this site, can be found in the generated PIWIK tracking code'));


### PR DESCRIPTION
Since 4.0.0 HeaderField has expected two constructor arugments - the 'Title' attribute is no longer optional. It was removed in silverstripe/framekwork#a68ba384781086f902708c7364550cc996c15b16 and is yet to be added back (this author thinks it should be). The side affect of this is that whenever the SiteConfig extension of this module is applied, a fatal error is seen when attempting to access the Settings section of the CMS. Adding a Title the same as the Name is the simplest fix.

Although Piwik has since changed name to Matomo, I believe it is best to aim for consistency - and https://github.com/wernerkrauss/silverstripe-piwik/issues/7 exists to rename the module (which would also involve changing code based references to the old name).